### PR TITLE
Potential fix for code scanning alert no. 30: DOM text reinterpreted as HTML

### DIFF
--- a/docs/jsdoc-clean/scripts/core.js
+++ b/docs/jsdoc-clean/scripts/core.js
@@ -324,29 +324,50 @@ function hideTocOnSourcePage() {
 }
 
 function getPreTopBar(id, lang = '') {
+    // create top bar container
+    var topBarContainer = document.createElement('div');
+    topBarContainer.className = 'pre-top-bar-container';
+
+    // language name container
+    var langNameContainer = document.createElement('div');
+    langNameContainer.className = 'code-lang-name-container';
+
+    var langName = document.createElement('div');
+    langName.className = 'code-lang-name';
+    // ensure the language name is treated as text, not HTML
+    langName.textContent = (lang || '').toLocaleUpperCase();
+
+    langNameContainer.appendChild(langName);
+
     // tooltip
-    var tooltip = '<div class="tooltip" id="tooltip-' + id + '">Copied!</div>';
+    var tooltip = document.createElement('div');
+    tooltip.className = 'tooltip';
+    tooltip.id = 'tooltip-' + id;
+    tooltip.textContent = 'Copied!';
 
-    // template of copy to clipboard icon container
-    var copyToClipboard =
-        '<button aria-label="copy code" class="icon-button copy-code" onclick="copyFunction(\'' +
-        id +
-        '\')"><svg class="sm-icon" alt="click to copy"><use xlink:href="#copy-icon"></use></svg>' +
-        tooltip +
-        '</button>';
+    // copy to clipboard button
+    var copyButton = document.createElement('button');
+    copyButton.setAttribute('aria-label', 'copy code');
+    copyButton.className = 'icon-button copy-code';
+    copyButton.setAttribute('onclick', "copyFunction('" + id + "')");
 
-    var langNameDiv =
-        '<div class="code-lang-name-container"><div class="code-lang-name">' +
-        lang.toLocaleUpperCase() +
-        '</div></div>';
+    var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('class', 'sm-icon');
+    svg.setAttribute('alt', 'click to copy');
 
-    var topBar =
-        '<div class="pre-top-bar-container">' +
-        langNameDiv +
-        copyToClipboard +
-        '</div>';
+    var use = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+    use.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', '#copy-icon');
 
-    return topBar;
+    svg.appendChild(use);
+
+    copyButton.appendChild(svg);
+    copyButton.appendChild(tooltip);
+
+    // assemble top bar
+    topBarContainer.appendChild(langNameContainer);
+    topBarContainer.appendChild(copyButton);
+
+    return topBarContainer;
 }
 
 function getPreDiv() {
@@ -387,9 +408,9 @@ function processAllPre() {
         var id = 'ScDloZOMdL' + idx;
 
         var lang = pre.getAttribute('data-lang') || 'code';
-        var topBar = getPreTopBar(id, lang);
+        var topBarElement = getPreTopBar(id, lang);
 
-        div.innerHTML = topBar;
+        div.appendChild(topBarElement);
 
         pre.style.maxHeight = preMaxHeight + 'px';
         pre.id = id;


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/30](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/30)

In general, the problem is that untrusted text (`data-lang`) is inserted into an HTML string and written with `innerHTML`, allowing the text to be interpreted as HTML rather than as plain text. To fix this, either (a) HTML-escape the untrusted text before concatenating it into the string, or (b) avoid building HTML strings for the dynamic part and instead create DOM elements and set their `textContent`/`innerText` safely.

The least invasive and clearest fix here is to change `getPreTopBar` to construct the top bar DOM using `document.createElement` / `appendChild`, setting `textContent` for the language name and leaving the rest of the structure (tooltip and copy button) as actual elements. Then, in `processAllPre`, instead of assigning `div.innerHTML = topBar;`, we append the created DOM nodes that `getPreTopBar` returns. This preserves all existing functionality (same structure, same IDs, same attributes) but ensures that `lang` is always treated as text, not HTML.

Concretely:

- Modify `getPreTopBar(id, lang = '')` so it:
  - Creates a top bar container `<div class="pre-top-bar-container">`.
  - Builds the tooltip `<div class="tooltip" id="tooltip-...">Copied!</div>`.
  - Builds the copy button as a `<button>` with the same classes, `aria-label`, `onclick`, and a nested `<svg><use xlink:href="#copy-icon"></use></svg>`.
  - Builds the language name container `<div class="code-lang-name-container"><div class="code-lang-name">...</div></div>` and sets the inner div’s `textContent = lang.toLocaleUpperCase()`.
  - Appends lang container and copy button to the top bar container.
  - Returns the DOM element instead of an HTML string.
- Update `processAllPre` so:
  - The result of `getPreTopBar(id, lang)` is stored into a variable like `topBarElement`.
  - `div.appendChild(topBarElement)` is used instead of `div.innerHTML = topBar;`.
- No new imports are needed; we use standard DOM APIs only.

All edits are in docs/jsdoc-clean/scripts/core.js, in the shown regions around `getPreTopBar` and `processAllPre`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
