### PR TITLE
Potential fix for code scanning alert no. 20: Missing rate limiting

### DIFF
--- a/routes/auth/login/loginRoute.js
+++ b/routes/auth/login/loginRoute.js
@@ -30,11 +30,20 @@ import {
   getGeoLocation,
   validateDeviceId,
 } from '#utils/helpers/deviceSessionHelper.js';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
+const loginRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 router.post(
   '/auth/login',
+  loginRateLimiter,
   validateMiddleware(loginValidate),
   async (req, res) => {
     const { ipAddress, userAgent } = getRequestInfo(req);


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/20](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/20)

In general, the best fix is to add a dedicated rate-limiting middleware to the `/auth/login` route so that excessive requests from the same client are rejected early with HTTP 429, before hitting the expensive authorization logic. For Express, this is typically done with a library like `express-rate-limit`. This middleware should be added to the route’s middleware chain rather than rewriting existing logic, so that existing behavior (login attempts tracking, logging, token generation) remains unchanged for legitimate traffic.

Concretely, in `routes/auth/login/loginRoute.js`, we can import `express-rate-limit`, define a login-specific limiter (e.g., keyed by IP, with a reasonable maximum number of requests per time window), and insert that limiter as a middleware between the path string (`'/auth/login'`) and `validateMiddleware(loginValidate)`. That way, requests exceeding the configured threshold will be short-circuited and never reach any of the authorization code paths that CodeQL has identified. The only required changes are: (1) add a new import for `express-rate-limit`, (2) define a `loginRateLimiter` constant near the router definition, and (3) add `loginRateLimiter` into the `router.post` call. No other files need to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
