### PR TITLE
Potential fix for code scanning alert no. 21: Missing rate limiting

### DIFF
--- a/routes/auth/restore/restoreVerificationTotp.js
+++ b/routes/auth/restore/restoreVerificationTotp.js
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 
 import prisma from '#utils/prismaConfig/prismaClient.js';
 import { findUserByUuidOrThrow } from '#utils/helpers/userHelpers.js';
@@ -13,7 +14,14 @@ import { getRequestInfo } from '#utils/helpers/authHelpers.js';
 
 const router = Router();
 
-router.post('/auth/restore/verify/totp', async (req, res) => {
+const restoreTotpLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+router.post('/auth/restore/verify/totp', restoreTotpLimiter, async (req, res) => {
   const { totpCode, restoreKey } = req.body;
   const { ipAddress, userAgent } = getRequestInfo(req);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/21](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/21)

In general, the problem should be fixed by adding a rate‑limiting middleware to this route so that repeated verification attempts are restricted per client (e.g., per IP) and/or per restore key. In an Express app, this is typically done using a middleware such as `express-rate-limit` (or a similar well‑known library) that counts requests over a time window and rejects or slows down excess requests.

For this specific file, the least intrusive, backward‑compatible fix is:
- Import a rate‑limiting library (e.g., `express-rate-limit`).
- Create a limiter tailored for this endpoint (for example, a small number of attempts per 15 minutes).
- Apply that limiter only to this route by passing it as middleware before the async handler, without altering the handler’s internal logic.

Concretely:
- At the top of `routes/auth/restore/restoreVerificationTotp.js`, add an import for `express-rate-limit`.
- After `const router = Router();`, define a `restoreTotpLimiter` with conservative values (e.g., 5–10 attempts per 15 minutes).
- Change the route definition from `router.post('/auth/restore/verify/totp', async (req, res) => { ... })` to `router.post('/auth/restore/verify/totp', restoreTotpLimiter, async (req, res) => { ... })`.

This keeps all existing behavior but adds rate limiting to mitigate abuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
