### PR TITLE
Potential fix for code scanning alert no. 37: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/routes/users/get/getCloudinarySignature.js
+++ b/routes/users/get/getCloudinarySignature.js
@@ -41,8 +41,8 @@ router.get(
       .join('&');
 
     const signature = crypto
-      .createHash('sha1')
-      .update(toSign + api_secret)
+      .createHmac('sha256', api_secret)
+      .update(toSign)
       .digest('hex');
 
     logCloudinarySignatureSuccess(userUuid, ip);


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/37](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/37)

In general, to fix this kind of problem you should avoid weak or broken algorithms (like MD5 or SHA‑1) for security‑sensitive operations, and instead use modern algorithms such as SHA‑256 or higher, preferably via HMAC when a secret key is involved. Keyed MACs (HMAC) provide stronger security properties than ad‑hoc concatenation of a secret with data and hashing, and using SHA‑256 avoids known weaknesses of SHA‑1.

For this specific file, the single best fix that preserves existing behavior as much as possible while strengthening security is:

- Replace the SHA‑1 hash with an HMAC using SHA‑256:
  - Change `crypto.createHash('sha1').update(toSign + api_secret)` to `crypto.createHmac('sha256', api_secret).update(toSign)`.
- Keep the rest of the logic (parameter sorting, joining, timestamp, upload preset) unchanged so that the structure of the signature remains the same from the caller’s perspective, apart from the stronger algorithm.
- No new imports are needed because `crypto` is already imported, and both `createHmac` and `sha256` are part of Node’s standard `crypto` module.

All changes are confined to `routes/users/get/getCloudinarySignature.js`, lines 43‑46, where the signature is computed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
