### PR TITLE
Potential fix for code scanning alert no. 28: Missing rate limiting

### DIFF
--- a/routes/auth/yandex/disable/yandexDisableRoute.js
+++ b/routes/auth/yandex/disable/yandexDisableRoute.js
@@ -12,12 +12,21 @@ import {
   logYandexOAuthDisableSuccess,
   logYandexOAuthDisableFailure,
 } from '#utils/loggers/authLoggers.js';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
+
+const yandexDisableRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit each IP to 20 requests per windowMs for this route
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 router.post(
   '/auth/oauth/yandex/disable',
   authenticateMiddleware,
+  yandexDisableRateLimiter,
   validateMiddleware(emailConfirmValidate),
   async (req, res) => {
     const { ipAddress, userAgent } = getRequestInfo(req);


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/28](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/28)

In general, the problem should be fixed by adding rate limiting middleware to HTTP handlers that perform authentication/authorization or other costly operations. In an Express app, the common approach is to use a middleware like `express-rate-limit` to cap requests per IP (or per user) over a given time window. This middleware should be placed before the expensive or sensitive logic so that abusive traffic is rejected early.

For this specific route, the least invasive fix that doesn’t change existing behavior is to add a rate‑limiting middleware into the route’s middleware chain, between `authenticateMiddleware` and the validator, or directly after them. We can use the `express-rate-limit` package and configure a limiter tailored to this endpoint, for example allowing a small number of disable attempts per 15 minutes from the same IP. Implementation steps within `routes/auth/yandex/disable/yandexDisableRoute.js`:

1. Add an import for `express-rate-limit`.
2. Define a `yandexDisableRateLimiter` using `rateLimit({ windowMs, max, standardHeaders, legacyHeaders, keyGenerator })`. To avoid assumptions about the wider codebase, we’ll use a straightforward per‑IP limiter and, where possible, incorporate `req.userUuid` into the key so authenticated users can be limited individually if desired. Since we can’t touch other files, we’ll keep it simple and just use the default IP‑based key.
3. Insert `yandexDisableRateLimiter` into the `router.post` middleware list, so that it runs after authentication (to ensure we’re limiting authenticated calls from the same client) or before, depending on preference. To avoid impacting auth behavior, we’ll place it after `authenticateMiddleware` and before `validateMiddleware(emailConfirmValidate)`.

All changes are confined to `routes/auth/yandex/disable/yandexDisableRoute.js`: one new import, one new constant definition, and an extra middleware argument in the `router.post` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
