### PR TITLE
Potential fix for code scanning alert no. 15: Missing rate limiting

### DIFF
--- a/routes/auth/google/connect/googleConnectRoute.js
+++ b/routes/auth/google/connect/googleConnectRoute.js
@@ -14,6 +14,7 @@ import {
   logGoogleOAuthSuccess,
   logGoogleOAuthFailure,
 } from '#utils/loggers/authLoggers.js';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
@@ -23,8 +24,16 @@ const oauth2Client = new OAuth2Client(
   'postmessage',
 );
 
+const googleConnectRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit each IP to 20 connect attempts per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 router.post(
   '/auth/oauth/google/connect',
+  googleConnectRateLimiter,
   authenticateMiddleware,
   async (req, res) => {
     const { ipAddress, userAgent } = getRequestInfo(req);


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/15](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/15)

In general, this kind of problem is fixed by adding a rate‑limiting middleware to the route so that each client (typically identified by IP) can only trigger the expensive authorization flow a bounded number of times within a time window. In Express, a common approach is to use the well‑known `express-rate-limit` package to define a limiter and apply it to specific routes or routers.

The best fix here, without changing existing functionality, is to:  
1. Import `express-rate-limit` in `routes/auth/google/connect/googleConnectRoute.js`.  
2. Define a limiter specifically for Google connect attempts (e.g., with a reasonable window and max count, such as 10–20 attempts per 15 minutes).  
3. Insert this limiter as middleware in the `router.post('/auth/oauth/google/connect', ...)` chain, between the route path and `authenticateMiddleware` (or immediately after it), so that requests exceeding the limit are rejected before performing any expensive work.  
4. Configure the limiter to return a clear 429 response message when the limit is exceeded.

Concretely, in `routes/auth/google/connect/googleConnectRoute.js`, you would add a `RateLimit` (or `rateLimit`) import at the top, create a `googleConnectRateLimiter` constant after the `oauth2Client` definition, and update the `router.post` call to include this limiter in the middleware list. No existing handler logic needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
