### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/routes/auth/github/disable/githubDisableRoute.js
+++ b/routes/auth/github/disable/githubDisableRoute.js
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { handleRouteError } from '#utils/handlers/handleRouteError.js';
 import { authenticateMiddleware } from '#middlewares/http/authenticateMiddleware.js';
 import { validateAndDeleteConfirmationCode } from '#utils/helpers/confirmationHelpers.js';
@@ -16,8 +17,16 @@ import { getUserOAuthEnabledByUserId } from '#utils/helpers/userHelpers.js';
 
 const router = Router();
 
+const githubDisableRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit each IP to 20 disable requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 router.post(
   '/auth/oauth/github/disable',
+  githubDisableRateLimiter,
   authenticateMiddleware,
   validateMiddleware(emailConfirmValidate),
   async (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/13](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/13)

In general, to fix missing rate limiting for an Express route, you add a rate‑limiting middleware (for example from `express-rate-limit`) and apply it either globally, to a router, or to the specific route. This limits how often a client (typically identified by IP) can hit the expensive or security‑sensitive endpoint in a time window, mitigating denial‑of‑service attempts.

For this specific route, the least disruptive fix is to import a well‑known rate‑limit middleware (`express-rate-limit`), define a limiter tailored for this GitHub OAuth disable operation, and apply it only to the `/auth/oauth/github/disable` POST route. This preserves existing behavior for all other routes and doesn’t change the business logic of the handler. Concretely in `routes/auth/github/disable/githubDisableRoute.js`, we will: (1) add an import for `express-rate-limit`, (2) create a `githubDisableRateLimiter` instance (e.g., allowing a small number of disable attempts per 15 minutes per IP), and (3) insert `githubDisableRateLimiter` into the middleware chain before `authenticateMiddleware` on this route. No other functions or files need to change based on the provided snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
