### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/routes/auth/google/connect/googleVerifyRoute.js
+++ b/routes/auth/google/connect/googleVerifyRoute.js
@@ -14,11 +14,20 @@ import {
   logGoogleOAuthConfirmSuccess,
   logGoogleOAuthConfirmFailure,
 } from '#utils/loggers/authLoggers.js';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
 
+const googleConfirmConnectLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // limit each IP to 10 confirmation attempts per window
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 router.post(
   '/auth/oauth/google/confirm-connect',
+  googleConfirmConnectLimiter,
   authenticateMiddleware,
   validateMiddleware(emailConfirmValidate),
   async (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/17](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/17)

In general, to fix missing rate limiting on an authorization/confirmation endpoint, we introduce a rate-limiting middleware that constrains how often a client (e.g., by IP or by authenticated user ID) can call the route within a time window. This prevents brute-force attempts on confirmation codes and mitigates denial-of-service risks from repeated expensive operations (database access, temp-store access, etc.).

For this specific route in `routes/auth/google/connect/googleVerifyRoute.js`, the best minimal-change fix is to use a standard library like `express-rate-limit` to define a limiter for this endpoint and insert it into the middleware chain for `POST /auth/oauth/google/confirm-connect`. We will:
- Add an import for `express-rate-limit`.
- Define a limiter instance configured for short bursts on this confirmation endpoint (for example, a modest number of attempts per 15 minutes) using the default keying (by IP), which is appropriate for an HTTP service.
- Apply this limiter as a middleware argument before `authenticateMiddleware` (or just after it; order is not security‑critical here, but adding it right after router creation and before other middlewares keeps behavior simple).
We will not change the route’s core logic or its response formats; only the rate limiting behavior will be added.

Concretely:
- At the top of `routes/auth/google/connect/googleVerifyRoute.js`, add `import rateLimit from 'express-rate-limit';`.
- After `const router = Router();`, define a `googleConfirmConnectLimiter` using `rateLimit({ windowMs: ..., max: ..., standardHeaders: true, legacyHeaders: false })`.
- Modify the `router.post` call to insert `googleConfirmConnectLimiter` between the path and `authenticateMiddleware`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
