### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL scheme check

### DIFF
--- a/utils/validators/boardValidators.js
+++ b/utils/validators/boardValidators.js
@@ -29,7 +29,7 @@ export const sanitizeInput = (input) => {
   return input
     .trim()
     .replace(/[<>]/g, '')
-    .replace(/javascript:/gi, '')
+    .replace(/\b(?:javascript|data|vbscript):/gi, '')
     .replace(/on\w+=/gi, '')
     .substring(0, 64);
 };


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/5](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/5)

To fix the problem, extend the sanitization to remove not only `javascript:` but also `data:` and `vbscript:` URL schemes in a case‑insensitive way. This keeps the existing behavior (trimming, stripping `<`/`>`, removing inline event handlers, limiting length) but closes the gap where an attacker could use `data:` or `vbscript:` instead of `javascript:`.

The best way, without changing existing functionality, is to adjust the regex on line 32 to cover all three schemes in a single case‑insensitive expression, e.g. `/\b(?:javascript|data|vbscript):/gi`. Using a word boundary helps avoid stripping unrelated text like `foojavascriptx` in the middle of a word, while still catching scheme prefixes and similar uses. No new imports or helper functions are needed; this is a localized change in `sanitizeInput` in `utils/validators/boardValidators.js`.

Specifically:
- In `sanitizeInput` (around lines 29–34), replace the `.replace(/javascript:/gi, '')` call with `.replace(/\b(?:javascript|data|vbscript):/gi, '')`.
- Leave all other logic intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
