### PR TITLE
Potential fix for code scanning alert no. 36: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "xss-clean": "^0.1.4",
     "yamljs": "^0.3.0",
     "yup": "^1.6.1",
-    "zxcvbn": "^4.4.2"
+    "zxcvbn": "^4.4.2",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",

--- a/utils/validators/taskValidators.js
+++ b/utils/validators/taskValidators.js
@@ -3,6 +3,7 @@
  * @description Валидаторы для задач.
  */
 import { validateBooleanField, validateTitleField } from './commonValidators.js';
+import sanitizeHtml from 'sanitize-html';
 
 /**
  * Проверяет, является ли строка валидным UUID v4
@@ -26,12 +27,13 @@ export const isValidUUID = (uuid) => {
 export const sanitizeInput = (input) => {
   if (typeof input !== 'string') return '';
 
-  return input
-    .trim()
-    .replace(/[<>]/g, '')
-    .replace(/javascript:/gi, '')
-    .replace(/on\w+=/gi, '')
-    .substring(0, 64);
+  const trimmed = input.trim();
+  const sanitized = sanitizeHtml(trimmed, {
+    allowedTags: [],
+    allowedAttributes: {},
+  });
+
+  return sanitized.substring(0, 64);
 };
 
 /**


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/36](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/36)

In general, the best fix is to avoid writing ad‑hoc HTML/JS sanitization and instead delegate to a well‑tested sanitization/escaping mechanism. In this context, we should stop trying to partially strip script-related substrings (`javascript:`, `on\w+=`) and instead either (a) escape angle brackets to neutralize HTML, or (b) use a library that is explicitly designed for sanitizing HTML input. This avoids the multi‑character–sanitization pitfall and significantly reduces the risk of injection.

The minimal change that keeps existing functionality (trim, length limit, and removal/neutralization of HTML/script content) while addressing the CodeQL concern is:

- Replace the manual regex-based removal (`/[<>]/g`, `/javascript:/gi`, `/on\w+=/gi`) with a single, robust sanitization step using a library such as `sanitize-html`.
- Preserve the surrounding behavior: still accept only strings, still trim whitespace, still limit to 64 characters at the end.
- Add an import for `sanitize-html` at the top of `utils/validators/taskValidators.js` without altering existing imports.

Concretely:

1. Add `import sanitizeHtml from 'sanitize-html';` at the top of `utils/validators/taskValidators.js`.
2. Rewrite `sanitizeInput` to:
   - Return `''` if `input` is not a string.
   - `trim()` the string.
   - Pass it to `sanitizeHtml` (optionally with a strict configuration such as allowing no tags).
   - Apply `.substring(0, 64)` to the sanitized result.
3. Remove the manual `.replace` calls. This eliminates the `on\w+=` multi‑character sanitization pattern that CodeQL flags.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
