### PR TITLE
Potential fix for code scanning alert no. 31: Bad HTML filtering regexp

### DIFF
--- a/docs/jsdoc-clean/scripts/third-party/hljs-original.js
+++ b/docs/jsdoc-clean/scripts/third-party/hljs-original.js
@@ -4012,7 +4012,7 @@ var hljs = (function () {
         },
         hljs.COMMENT(
           /<!--/,
-          /-->/,
+          /--!?>/,
           {
             relevance: 10
           }


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/31](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/31)

In general, the problem is that the end‑of‑comment regexp only matches `-->` but not `--!>`, even though browsers treat both as comment terminators. To fix this, the regexp should allow an optional `!` before the closing `>`, i.e., match `--` followed by an optional `!` and then `>`. That can be achieved with `/--!?>/` (or equivalently `/--(?:!>|\>)/`).

The best minimal fix is to modify the second argument to `hljs.COMMENT` on the indicated lines so that the comment end pattern becomes `/--!?>/`. This keeps the structure and behavior identical except that comments ending with `--!>` will now be treated as comments too. No other parts of the language definition, imports, or helpers need to change.

Specifically, in `docs/jsdoc-clean/scripts/third-party/hljs-original.js` around lines 4013–4018, change the end pattern from `/-->/` to `/--!?>/`. No additional functions or dependencies are required; this is just a local regexp tweak.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
