### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/routes/users/get/getCloudinarySignature.js
+++ b/routes/users/get/getCloudinarySignature.js
@@ -46,7 +46,7 @@ router.get(
       .digest('hex');
 
     logCloudinarySignatureSuccess(userUuid, ip);
-    console.info(`Подпись: ${api_key} ${timestamp} ${signature}`);
+    console.info(`Подпись для пользователя ${userUuid} успешно создана, timestamp: ${timestamp}`);
 
     return res.json({
       api_key,


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/1](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/1)

In general, the fix is to avoid logging secrets or credential-like configuration values (`api_key`, `api_secret`, signatures, tokens, etc.) in clear text. If logging is needed for debugging or auditing, log only non-sensitive metadata, such as that a signature was generated, the user ID, and possibly the timestamp, but not the key or the signature value.

For this specific code, the minimal, non-breaking fix is to change the `console.info` call on line 49 so that it does not include `api_key` or `signature`. We can either remove that log entirely (since `logCloudinarySignatureSuccess` already records the successful attempt) or log only the fact that a signature was generated plus non-sensitive details (e.g., timestamp and maybe user UUID). No changes are needed to the response body: the function must still return `api_key`, `timestamp`, and `signature` to the caller. No new imports or helper methods are required: we just modify the string being logged.

Concretely:
- In `routes/users/get/getCloudinarySignature.js`, replace line 49:
  - From: `console.info(\`Подпись: ${api_key} ${timestamp} ${signature}\`);`
  - To something like: `console.info(\`Подпись для пользователя ${userUuid} успешно создана, timestamp: ${timestamp}\`);`
This preserves logging of the event for operational insight while removing sensitive data from logs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
