### PR TITLE
Potential fix for code scanning alert no. 10: Overly permissive regular expression range

### DIFF
--- a/docs/jsdoc-docolatte/scripts/docolatte.js
+++ b/docs/jsdoc-docolatte/scripts/docolatte.js
@@ -22884,7 +22884,7 @@ function requireTypescript () {
 	    keywords: KEYWORDS$1,
 	    // this will be extended by TypeScript
 	    exports: { PARAMS_CONTAINS, CLASS_REFERENCE },
-	    illegal: /#(?![$_A-z])/,
+	    illegal: /#(?![$_A-Za-z])/,
 	    contains: [
 	      hljs.SHEBANG({
 	        label: "shebang",


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/10](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/10)

In general, the problem is solved by replacing ambiguous or overly broad ranges like `A-z` with explicit ranges that only cover the intended characters, such as `A-Z` or `A-Za-z`. This avoids unintentionally including punctuation characters that lie between `Z` and `a` in ASCII.

In this specific case, the problematic regex is on line 22887:

```js
illegal: /#(?![$_A-z])/,
```

The negative lookahead `(?![$_A-z])` appears to be checking that a `#` is not followed by a valid identifier-start character (for example, in contexts where `#` should be illegal unless starting a private field). JavaScript identifier starts are `$`, `_`, and letters; the current `A-z` attempts to approximate letters but pulls in unwanted characters. The least intrusive correction that preserves existing semantics is to change `A-z` to `A-Za-z`, yielding:

```js
illegal: /#(?![$_A-Za-z])/,
```

This continues to allow `$`, `_`, and ASCII letters while no longer including the unintended punctuation characters. No new imports or helper methods are required; it is a simple in-place regex modification in `docs/jsdoc-docolatte/scripts/docolatte.js` at the shown location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
