### PR TITLE
Potential fix for code scanning alert no. 26: Missing rate limiting

### DIFF
--- a/routes/auth/yandex/connect/yandexConnectRoute.js
+++ b/routes/auth/yandex/connect/yandexConnectRoute.js
@@ -13,12 +13,21 @@ import {
   logYandexOAuthSuccess,
   logYandexOAuthFailure,
 } from '#utils/loggers/authLoggers.js';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
+
+const yandexConnectLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit each IP to 20 Yandex connect requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 router.post(
   '/auth/oauth/yandex/connect',
   authenticateMiddleware,
+  yandexConnectLimiter,
   async (req, res) => {
     const { ipAddress, userAgent } = getRequestInfo(req);
     const userUuid = req.userUuid;


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/26](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/26)

In general, the problem is best fixed by adding a rate-limiting middleware to this sensitive route so that repeated attempts (whether accidental or malicious) are throttled. For Express, a standard approach is to use a well-known library such as `express-rate-limit` and apply it to the route as an extra middleware before the async handler. This controls the maximum number of allowed requests per client over a time window, preventing brute-force and DoS attacks targeting this endpoint.

Concretely for this file, we can import `rateLimit` (or `RateLimit`) from `express-rate-limit`, define a limiter specifically for the Yandex connect endpoint (for example, limiting to a small number of attempts per 15 minutes per IP), and insert that limiter into the `router.post` middleware chain between `authenticateMiddleware` and the async handler. This preserves all existing behavior but adds protection against high-frequency calls. The change should be localized to `routes/auth/yandex/connect/yandexConnectRoute.js`: (1) add the import near the top of the file; (2) define a `yandexConnectLimiter` constant after creating the router; and (3) update the `router.post('/auth/oauth/yandex/connect', ...)` registration to include `yandexConnectLimiter` as a middleware. No existing functions need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
