### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/routes/auth/google/connect/googleAuthRoute.js
+++ b/routes/auth/google/connect/googleAuthRoute.js
@@ -154,7 +154,15 @@ router.post('/auth/oauth/google', googleOAuthRateLimiter, async (req, res) => {
 
     if (avatarUrl) {
       const hasAvatar = Boolean(user.avatarUrl);
-      const isCloud = user.avatarUrl?.includes('res.cloudinary.com');
+      let isCloud = false;
+      if (user.avatarUrl) {
+        try {
+          const parsedUrl = new URL(user.avatarUrl);
+          isCloud = parsedUrl.hostname === 'res.cloudinary.com';
+        } catch {
+          isCloud = false;
+        }
+      }
       if (!hasAvatar || !isCloud) {
         await uploadAvatarAndUpdateUser(
           user.id,


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/3](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/3)

In general, the problem must be fixed by parsing the URL and checking its hostname (and possibly protocol) instead of doing a substring search. For Cloudinary URLs, we should confirm that `user.avatarUrl` is a valid URL whose `hostname` is exactly `res.cloudinary.com` (or another explicitly allowed variant), instead of just checking whether the string contains that text anywhere.

In this specific file, line 157 sets `isCloud` as:

```js
const isCloud = user.avatarUrl?.includes('res.cloudinary.com');
```

We should replace this with logic that:

1. Safely attempts to construct a `URL` object from `user.avatarUrl`.
2. If URL parsing fails, treats `isCloud` as `false`.
3. If parsing succeeds, checks `parsedUrl.hostname === 'res.cloudinary.com'` (optionally allow subdomains via a controlled list, but the code as written appears to care only about Cloudinary’s main host).

Node and modern browsers provide a built-in `URL` class, so we do not need external libraries. Because we only use this for a single check, we can inline the parsing logic at the point of use.

Concretely: around lines 155–159, we change the `isCloud` assignment to use `new URL(...)` in a try/catch. No imports or signatures elsewhere need to be changed. Functionality is preserved: `isCloud` is still a boolean, but now it is true only when `user.avatarUrl` is a well-formed Cloudinary URL, instead of any string containing that substring.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
