### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/routes/auth/github/connect/githubAuthRoute.js
+++ b/routes/auth/github/connect/githubAuthRoute.js
@@ -157,7 +157,16 @@ router.post('/auth/oauth/github', githubOAuthLimiter, async (req, res) => {
 
     if (githubUser.avatar_url) {
       const hasAvatar = Boolean(user.avatarUrl);
-      const isCloudinary = user.avatarUrl?.includes('res.cloudinary.com');
+      let isCloudinary = false;
+      if (hasAvatar && typeof user.avatarUrl === 'string') {
+        try {
+          const parsedUrl = new URL(user.avatarUrl);
+          // Only treat as Cloudinary if the hostname matches exactly
+          isCloudinary = parsedUrl.hostname === 'res.cloudinary.com';
+        } catch {
+          isCloudinary = false;
+        }
+      }
       if (!hasAvatar || !isCloudinary) {
         await uploadAvatarAndUpdateUser(
           user.id,


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/2](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/2)

In general, to fix this class of issue, treat URLs as structured data rather than plain strings: parse the URL and validate its `hostname` (or `host`) against an explicit allowlist of trusted hosts, instead of using substring checks like `includes()`. This avoids accepting values such as `https://res.cloudinary.com.evil.com` or `https://evil.com/res.cloudinary.com/...`.

For this specific code, we want to preserve semantics: determine whether the existing `user.avatarUrl` already points to the intended Cloudinary host so that we can skip re-uploading if it does. The best way is to parse `user.avatarUrl` with the standard `URL` constructor (available in Node.js) and then compare the parsed hostname against an allowed set such as `['res.cloudinary.com']` (or any project-specific Cloudinary hostnames you use). If parsing fails (invalid URL), we should treat it as not being a Cloudinary URL. We must not change imports other than possibly adding standard-library functionality; in Node, `URL` is globally available, so no new import is necessary.

Concretely, in `routes/auth/github/connect/githubAuthRoute.js`, replace:

```js
const hasAvatar = Boolean(user.avatarUrl);
const isCloudinary = user.avatarUrl?.includes('res.cloudinary.com');
if (!hasAvatar || !isCloudinary) {
```

with logic that:

1. Checks `hasAvatar` as before.
2. Safely parses `user.avatarUrl` using `new URL(...)` inside a `try/catch`.
3. Defines `isCloudinary` as `true` only if the parsed hostname exactly matches `res.cloudinary.com` (or another exact hostname you trust).
4. Falls back to `false` when parsing fails or hostname does not match.

No additional dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
