### PR TITLE
Potential fix for code scanning alert no. 34: Incomplete string escaping or encoding

### DIFF
--- a/docs/jsdoc-clean/scripts/third-party/tocbot.js
+++ b/docs/jsdoc-clean/scripts/third-party/tocbot.js
@@ -338,10 +338,16 @@ function BuildHtml(options) {
         })
 
         // Add the active class to the active tocLink.
+        var escapedId
+        if (typeof window !== 'undefined' && window.CSS && typeof window.CSS.escape === 'function') {
+            escapedId = window.CSS.escape(topHeader.id)
+        } else {
+            escapedId = topHeader.id.replace(/([\\ #;&,.+*~':"!^$[\]()=>|/@])/g, '\\$1')
+        }
         var activeTocLink = tocElement
             .querySelector('.' + options.linkClass +
                 '.node-name--' + topHeader.nodeName +
-                '[href="' + options.basePath + '#' + topHeader.id.replace(/([ #;&,.+*~':"!^$[\]()=>|/@])/g, '\\$1') + '"]')
+                '[href="' + options.basePath + '#' + escapedId + '"]')
         if (activeTocLink && activeTocLink.className.indexOf(options.activeLinkClass) === -1) {
             activeTocLink.className += SPACE_CHAR + options.activeLinkClass
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/34](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/34)

In general, any custom escaping routine used to sanitize a string for inclusion in a CSS selector should either (1) delegate to a well-tested API like `CSS.escape` when available, or (2) at least ensure that all meta-characters, including the backslash itself, are escaped consistently. The current code attempts to escape many CSS selector special characters with a single regex, but it omits `\`, which can break the intended escaping logic.

The best minimal-change fix here is to adjust the escaping so that backslashes are also escaped. The most robust way, without changing behavior elsewhere, is to use `CSS.escape` when it exists (modern browsers) and fall back to the existing regex-based escaping only when `CSS.escape` is unavailable. This keeps existing behavior for older environments while providing correct and complete escaping where supported. Concretely, in the `updateListActiveElement` function, replace the direct call to `topHeader.id.replace(/([ #;&,.+*~':"!^$[\]()=>|/@])/g, '\\$1')` with logic that:

1. Computes a local `escapedId` using `CSS.escape(topHeader.id)` if `window.CSS` and `window.CSS.escape` are available.
2. Otherwise, computes `escapedId` using the current regex, expanded to also escape `\` (i.e., add `\\` into the character class).
3. Uses `escapedId` in the `querySelector` string.

No new imports are necessary; `CSS.escape` is a built-in web API.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
