### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/routes/auth/yandex/connect/yandexAuthRoute.js
+++ b/routes/auth/yandex/connect/yandexAuthRoute.js
@@ -21,6 +21,16 @@ import {
   logYandexOAuthFailure,
 } from '#utils/loggers/authLoggers.js';
 
+function isCloudinaryUrl(avatarUrl) {
+  if (!avatarUrl) return false;
+  try {
+    const parsed = new URL(avatarUrl);
+    return parsed.hostname === 'res.cloudinary.com';
+  } catch {
+    return false;
+  }
+}
+
 const router = Router();
 
 const yandexOAuthLimiter = rateLimit({
@@ -159,7 +169,7 @@ router.post('/auth/oauth/yandex', yandexOAuthLimiter, async (req, res) => {
 
     if (avatarUrl) {
       const hasAvatar = Boolean(user.avatarUrl);
-      const isCloudinary = user.avatarUrl?.includes('res.cloudinary.com');
+      const isCloudinary = isCloudinaryUrl(user.avatarUrl);
       if (!hasAvatar || !isCloudinary) {
         await uploadAvatarAndUpdateUser(
           user.id,


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/4](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/4)

General fix: avoid substring checks on full URLs. Instead, parse the URL and validate its host (and optionally protocol) against an explicit whitelist or against a strict pattern. For Cloudinary, that means: parse `user.avatarUrl`, extract the hostname, and ensure it is exactly `res.cloudinary.com` or matches a deliberately allowed set (e.g., specific subdomains if needed).

Best concrete fix here without changing behavior: replace the `includes('res.cloudinary.com')` heuristic with a robust hostname check that still only answers “is this avatar URL hosted on Cloudinary?”. We can do this by:

1. Parsing `user.avatarUrl` with the standard `URL` constructor.
2. Checking that `url.hostname === 'res.cloudinary.com'`.
3. Handling invalid/malformed URLs gracefully by treating them as “not Cloudinary”.

Because we can’t edit other files, we’ll implement a small helper function in this file (e.g., `isCloudinaryUrl`) above the route code, and then replace the `includes` call with this helper. We don’t need extra npm dependencies; Node’s built-in `URL` class is enough.

Concretely in `routes/auth/yandex/connect/yandexAuthRoute.js`:

- Add a local helper:

```js
function isCloudinaryUrl(avatarUrl) {
  if (!avatarUrl) return false;
  try {
    const parsed = new URL(avatarUrl);
    return parsed.hostname === 'res.cloudinary.com';
  } catch {
    return false;
  }
}
```

- Replace line 162:

```js
const isCloudinary = user.avatarUrl?.includes('res.cloudinary.com');
```

with:

```js
const isCloudinary = isCloudinaryUrl(user.avatarUrl);
```

This preserves the surrounding logic: we still upload a new Yandex avatar if the user has no avatar or their avatar is not on Cloudinary, but we now decide “is Cloudinary” in a safe, host-aware way.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
