### PR TITLE
Potential fix for code scanning alert no. 9: Overly permissive regular expression range

### DIFF
--- a/docs/jsdoc-docolatte/scripts/docolatte.js
+++ b/docs/jsdoc-docolatte/scripts/docolatte.js
@@ -15598,7 +15598,7 @@ function requireJavascript () {
 	    keywords: KEYWORDS$1,
 	    // this will be extended by TypeScript
 	    exports: { PARAMS_CONTAINS, CLASS_REFERENCE },
-	    illegal: /#(?![$_A-z])/,
+	    illegal: /#(?![$_A-Za-z])/,
 	    contains: [
 	      hljs.SHEBANG({
 	        label: "shebang",


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/9](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/9)

In general, to fix overly permissive character ranges you replace ambiguous ranges like `A-z` with explicit, correct ranges such as `A-Za-z`, or otherwise enumerate only the characters you actually want to match. This avoids unintentionally including punctuation or control characters that fall between the endpoints in the ASCII table.

In this specific case, the `illegal` property is defined as `illegal: /#(?![$_A-z])/,` within the JavaScript language definition. This regex means: “`#` followed by a character that is not `$`, `_`, or in the range `A-z` is illegal.” To keep the existing intent while removing the problematic characters, we should change the range `A-z` to `A-Za-z`, so the pattern becomes `/#(?![$_A-Za-z])/`. This preserves the idea that code like `#foo` (used e.g. for private fields) is allowed, while still marking a `#` followed by non-identifier characters as illegal, but without incorrectly treating `#]`, `#^`, etc. as “legal” in the lookahead sense.

Only one line needs to be changed in `docs/jsdoc-docolatte/scripts/docolatte.js`, and no additional imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
