### PR TITLE
Potential fix for code scanning alert no. 8: Overly permissive regular expression range

### DIFF
--- a/docs/jsdoc-clean/scripts/third-party/hljs-original.js
+++ b/docs/jsdoc-clean/scripts/third-party/hljs-original.js
@@ -3704,7 +3704,7 @@ var hljs = (function () {
       keywords: KEYWORDS$1,
       // this will be extended by TypeScript
       exports: { PARAMS_CONTAINS },
-      illegal: /#(?![$_A-z])/,
+      illegal: /#(?![$_A-Za-z])/,
       contains: [
         hljs.SHEBANG({
           label: "shebang",


### PR DESCRIPTION
Potential fix for [https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/8](https://github.com/Kramarich0/SharkFlow-API/security/code-scanning/8)

In general, overly permissive ranges like `A-z` should be replaced with explicit upper- and lowercase ranges (e.g. `A-Za-z`) or, better yet, with an explicitly enumerated set that matches the intended identifier characters (e.g. `A-Za-z$_`). This avoids unintentionally including ASCII punctuation between `Z` and `a`.

For this specific case, the `illegal` pattern `/#(?![$_A-z])/` appears in the JavaScript language definition’s return object, and is intended to mark `#` as illegal unless it’s followed by something that starts a valid JavaScript “private name” or identifier-like construct. Elsewhere in Highlight.js, identifier regexes typically allow `$`, `_`, and ASCII letters; they do not rely on the `A-z` range. The minimal change that preserves intent is to replace `A-z` with `A-Za-z`, keeping `$` and `_` in the character class. Concretely, in `docs/jsdoc-clean/scripts/third-party/hljs-original.js`, around line 3707, change:

```js
illegal: /#(?![$_A-z])/,
```

to:

```js
illegal: /#(?![$_A-Za-z])/,
```

No new imports or helper methods are needed; this is a one-line regex refinement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
